### PR TITLE
move @electron-forge to dependencies, because new electron-forge 7.4.0 search for it

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,14 +26,14 @@
     "dev": "rollup -c -w --bundleConfigAsCjs=false"
   },
   "devDependencies": {
-    "@electron-forge/async-ora": "^6.0.0",
-    "@electron-forge/publisher-base": "^6.0.0",
     "@rollup/plugin-typescript": "^8.5.0",
     "@types/ali-oss": "^6.16.4",
     "rollup": "^3.0.0",
     "typescript": "^4.8.3"
   },
   "dependencies": {
+    "@electron-forge/async-ora": "^6.0.0",
+    "@electron-forge/publisher-base": "^6.0.0",
     "ali-oss": "^6.17.1"
   }
 }


### PR DESCRIPTION
当使用7.4.0的electron-forge时，调用 electron-forge publish会出现找不到electron-forge-publisher-oss错误：
```
An unhandled rejection has occurred inside Forge:
Error: Could not find a publish target with the name: electron-forge-publisher-oss. Make sure it's listed in the devDependencies of your package.json
at E:\eletron\test2\node_modules\@electron-forge\core\dist\api\publish.js:112:35
    at async _Task.taskFn (E:\eletron\test2\node_modules\@electron-forge\tracer\dist\index.js:58:20)
    at async _Task.run (E:\eletron\test2\node_modules\listr2\dist\index.cjs:2063:11)
```
经过与其他项目比对，发现会寻找node_modules\electron-forge-publisher-oss\node_modules\\@electron-forge 目录，
因此将package.json挪下地方，保证会有该目录，从而绕过该错误